### PR TITLE
Fix RconException not being thrown on auth error

### DIFF
--- a/rcon_mc/rcon.py
+++ b/rcon_mc/rcon.py
@@ -135,7 +135,7 @@ class client:
     except(error) as ret_val:
       return False
     if (response[0] == -1 ):
-      _manage_rcon_error("Authentication failure")
+      self._manage_rcon_error("Authentication failure")
       return False
     self.authenticated = True
     return True


### PR DESCRIPTION
fix error: global name '_manage_rcon_error' is not defined
on connect with incorrect auth credentials
